### PR TITLE
Allow multiple instances of RotaryEncoder to work at the same time

### DIFF
--- a/micropython_rotary_encoder/rotary_encoder_rp2.py
+++ b/micropython_rotary_encoder/rotary_encoder_rp2.py
@@ -4,8 +4,6 @@ from .rotary_encoder import RotaryEncoder
 
 
 class RotaryEncoderRP2(RotaryEncoder):
-    timer: Timer = None
-    alive: bool = True
 
     def __init__(
             self,
@@ -33,6 +31,8 @@ class RotaryEncoderRP2(RotaryEncoder):
             fast_ms=fast_ms,
             click_ms=click_ms,
         )
+        self.timer: Timer = None
+        self.alive: bool = True
 
         self._enable_irq()
 


### PR DESCRIPTION
# Use Case: 

I have a volume knob (Vol Up, Vol Down, and Mute) and a control knob (Left, Right, Perform Action) knob. 

# The issue

The current version of the code stores all variables on the CLASS and not on the INSTANCE, so all of these variables are shared between all of the instances.  

# Changes: 
- Moved all CLASS variables to be INSTANCE variables instead
- Added example file for multiple encoders.  